### PR TITLE
Fix typo for maintaining consistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ const KeyPair = require('./lib/crypto/key_pair');
 const {Tx} = require('./lib/structs');
 
 module.exports = {
-	IOST: IOST,
+    IOST: IOST,
     RPC: RPC,
     HTTPProvider: HTTPProvider,
     KeyPair: KeyPair,
-    Tx : Tx,
+    Tx: Tx,
 };

--- a/iost/iost.js
+++ b/iost/iost.js
@@ -4,7 +4,6 @@ const RPC = require('../lib/rpc');
 const {Tx} = require('../lib/structs');
 const HTTPProvider = require('../lib/provider/HTTPProvider');
 
-
 class txHandler {
     constructor(tx, rpc) {
         this.tx = tx;
@@ -23,13 +22,11 @@ class txHandler {
     onSuccess(c) {
         this.Success = c;
         return this
-
     }
 
     onFailed(c) {
         this.Failed = c;
         return this
-
     }
 
 

--- a/lib/crypto/codec.js
+++ b/lib/crypto/codec.js
@@ -70,7 +70,7 @@ class Codec {
             }
             buf2.writeUInt8(buf.readUInt8(i), j++)
         }
-        return buf2.slice(0,j)
+        return buf2.slice(0, j)
     }
 }
 

--- a/lib/crypto/signature.js
+++ b/lib/crypto/signature.js
@@ -9,7 +9,7 @@ class Signature {
     constructor(info, keyPair) {
         this.algorithm = keyPair.t;
         if (this.algorithm === Algo.Ed25519) {
-            this.sig = Buffer.from(nacl.sign(info, keyPair.seckey)).slice(0,64);
+            this.sig = Buffer.from(nacl.sign(info, keyPair.seckey)).slice(0, 64);
             this.pubkey = keyPair.pubkey
         } else if (this.algorithm === Algo.Secp256k1) {
             this.pubkey = Secp256k1.publicKeyCreate(keyPair.seckey);
@@ -24,7 +24,7 @@ class Signature {
         let c = new Codec();
         c.pushByte(this.algorithm);
         c.pushBytes(this.sig, true);
-        c.pushBytes(this.pubkey,true);
+        c.pushBytes(this.pubkey, true);
 
         return c._buf
     }


### PR DESCRIPTION
There are some code which is not consistent another codes. 
For example,

**1) Separation key & colon**
- When defining property of object, all codes have a space between key and `:`.

Good example)
```
    RPC: RPC,
    HTTPProvider: HTTPProvider,
    KeyPair: KeyPair,
```

Bad example)
There are some code which is not, like `Tx : Tx,`

**2) Separation comma & argument**
- When separating arguments with comma, add space between `,` and argument.

Good example)
```
c.pushBytes(this.sig, true);
```

Bad example)
```
this.sig = Buffer.from(nacl.sign(info, keyPair.seckey)).slice(0,64);
```

After this PR, all codes have consistency for 1) Separation key & colon, 2) Separation comma & argument

