### PR TITLE
Fix the usage of constructing IOST instance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const rpc = new IOST.RPC(new IOST.HTTPProvider("http://localhost:30001"));
 rpc.blockchain.getChainInfo().then(console.log);
 
 // init iost sdk
-let iost = new IOST({ // will use default setting if not set
+let iost = new IOST.IOST({ // will use default setting if not set
     gasPrice: 100,
     gasLimit: 100000,
     delay:0,
@@ -40,6 +40,3 @@ handler
     .listen(); // if not listen, only onPending or onFailed (at sending tx) will be called
 ```
 ## APIs
-
-
-


### PR DESCRIPTION
According to index.js, `module.exports` are defined like below:
```
module.exports = {
    IOST: IOST,
    RPC: RPC,
    HTTPProvider: HTTPProvider,
    KeyPair: KeyPair,
    Tx : Tx,
    Algorithm: Algorithm,
    Account: Account,
    TxHandler: TxHandler,
}
```

To instantiate IOST, you should do it with a statement `new IOST.IOST({...})` instead `new IOST({...})`.

Currently, instantiating IOST is wrongly described in README.md usage.

It should be fixed.