### PR TITLE
Add object style for calling iost.transfer

### DIFF
--- a/iost/iost.js
+++ b/iost/iost.js
@@ -50,6 +50,18 @@ class IOST {
      * @returns {Tx}
      */
     transfer(token, from, to, amount, memo = "") {
+        // For object-style input
+        if (arguments.length === 1 && typeof arguments[0] === 'object') {
+          const transferStructure = arguments[0]
+          return transfer(
+            transferStructure.token,
+            transferStructure.from,
+            transferStructure.to,
+            transferStructure.amount,
+            transferStructure.memo
+          )
+        }
+
         let t = this.callABI("token.iost", "transfer", [token, from, to, amount, memo]);
         t.addApprove("*", this.config.defaultLimit);
         t.addApprove("iost", amount);


### PR DESCRIPTION
Calling transfer like `const tx = iost.transfer(tokenSym, accountList[0].getID(), "admin", "55.000000001");` sometimes verbose.

I added object-style calling method for it.

After this PR it can be possible to call like below:
```
iost.transfer({
  token: 'iost',
  from: '...',
  to: '...',
  amount: '...',
  memo: '...',
})
```

I think the above one is more friendly from ethereum-experienced developers. 
How do you think about it? Please check it :)