### PR TITLE
Add util library

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const {Tx} = require('./lib/structs');
 const Algorithm = require('./lib/crypto/algorithm');
 const Account = require('./iost/account');
 const TxHandler = require('./iost/tx_handler');
+const Util = require('./lib/util');
 
 module.exports = {
 	IOST: IOST,
@@ -16,4 +17,5 @@ module.exports = {
     Algorithm: Algorithm,
     Account: Account,
     TxHandler: TxHandler,
+    Util: Util,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,15 @@
+const bs58 = require('bs58');
+
+/**
+ * In iost, private key mainly encoded with base58 string.
+ * To use it as a keypair, it should be decoded.
+ * @param  { string } encodedPrivateKey base58 encoded string for private key
+ * @return { string } decoded private key
+ */
+function decodePrivateKey (encodedPrivateKey) {
+  return bs58.decode(encodedPrivateKey);
+}
+
+module.exports = {
+  decodePrivateKey
+}


### PR DESCRIPTION
To decode private key from outer iost.js library, developer should install `bs58` library. It is not efficient since iost.js already have a `bs58` as a library.

It could be prevented if iost.js exposes some util library for it.

Please check. :)

@sswsdsn @wangyu0air 