### PR TITLE
Remove redundancy statement on iost.transfer

### DIFF
--- a/iost/iost.js
+++ b/iost/iost.js
@@ -51,7 +51,6 @@ class IOST {
      */
     transfer(token, from, to, amount, memo = "") {
         let t = this.callABI("token.iost", "transfer", [token, from, to, amount, memo]);
-        t.addApprove("*", this.config.defaultLimit);
         t.addApprove("iost", amount);
         return t;
     }


### PR DESCRIPTION
```
        let t = this.callABI("token.iost", "transfer", [token, from, to, amount, memo]);
```
In this statement, `this.callABI` already do `t.addApprove("*", this.config.defaultLimit);` internally.

So there is no reason to set defaultGasLimit twice when call `transfer`.
