### PR TITLE
update structs.js for using transfer function

### DIFF
--- a/lib/structs.js
+++ b/lib/structs.js
@@ -30,7 +30,7 @@ class Tx {
             throw "approve should not contain * token";
         }
         if (typeof amount !== 'number') {
-            throw "approve amount should be number";
+            amount = parseFloat(amount)
         }
         
         const m = amount.toExponential().match(/\d(?:\.(\d*))?e([+-]\d+)/);


### PR DESCRIPTION
when i call

iost.transfer('fromAccount', 'toAccount', '10.000', 'memo')

approve amount should be number message occurs.

so type cast to float when amount is type 'string'