### PR TITLE
Use `Math.trunc` instead of `parseInt`.

### DIFF
--- a/iost/tx_handler.js
+++ b/iost/tx_handler.js
@@ -96,9 +96,9 @@ class TxHandler {
             if (self.status === "idle") {
                 return
             }
-            if (self.status === "success" || self.status === "failed" || i > parseInt(times)) {
+            if (self.status === "success" || self.status === "failed" || i > Math.trunc(times)) {
                 clearInterval(id);
-                if (self.status !== "success" && self.status !== "failed" && i > parseInt(times)) {
+                if (self.status !== "success" && self.status !== "failed" && i > Math.trunc(times)) {
                     self.Failed("Error: tx " + self._hash + " on chain timeout.");
                 }
                 return
@@ -112,7 +112,7 @@ class TxHandler {
                 }
             }).catch(function (e) {
             })
-        }, parseInt(interval));
+        }, Math.trunc(interval));
     }
 
     static SimpleTx(contract, abi, args, config) {

--- a/lib/structs.js
+++ b/lib/structs.js
@@ -6,7 +6,7 @@ const KeyPair = require('./crypto/key_pair');
 class Tx {
     constructor(gasRatio, gasLimit) {
         this.gasRatio = gasRatio;
-        this.gasLimit = parseInt(gasLimit);
+        this.gasLimit = Math.trunc(gasLimit);
         this.actions = [];
         this.signers = [];
         this.signatures = [];
@@ -117,7 +117,7 @@ class Tx {
         let c = new Codec();
         c.pushInt64(this.time);
         c.pushInt64(this.expiration);
-        c.pushInt64(parseInt(this.gasRatio * 100));
+        c.pushInt64(Math.trunc(this.gasRatio * 100));
         c.pushInt64(this.gasLimit * 100);
         c.pushInt64(this.delay);
         c.pushInt(this.chain_id);


### PR DESCRIPTION
In some cases, `parseInt()` will return unexpected values.

```
parseInt(0.000001)
0
parseInt(0.00000001)
1
```

`Math.trunc()` is safer.